### PR TITLE
Fix the prompt when using new backplane

### DIFF
--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -20,6 +20,8 @@ BUILD_TAG="latest"
 EXEC_SCRIPT=
 TTY="-it"
 
+DEFAULT_BACKPLANE_CONFIG_DIR_LOCATION="$HOME/.config/backplane"
+
 while [ "$1" != "" ]; do
   case $1 in
     -e | --exec )           shift
@@ -191,6 +193,23 @@ then
   PORT_MAP_OPTS="--publish-all"
 fi
 
+## Check for backplane config dir override and then mount the directory if it exists
+if [ -z "$BACKPLANE_CONFIG_DIR" ]
+then
+  BACKPLANE_CONFIG_DIR=$DEFAULT_BACKPLANE_CONFIG_DIR_LOCATION
+fi
+
+if [ -d "$BACKPLANE_CONFIG_DIR" ]
+then
+  BACKPLANE_CONFIG_MOUNT="-v $BACKPLANE_CONFIG_DIR:/root/.config/backplane"
+  if [ -z $OCM_URL ] || [ $OCM_URL == "production" ]
+  then
+    BACKPLANE_CONFIG_MOUNT="$BACKPLANE_CONFIG_MOUNT -e BACKPLANE_CONFIG=/root/.config/backplane/config.json"
+  else
+    BACKPLANE_CONFIG_MOUNT="$BACKPLANE_CONFIG_MOUNT -e BACKPLANE_CONFIG=/root/.config/backplane/config.$OCM_URL.json"
+  fi
+fi
+
 ### start container
 CONTAINER=$(${CONTAINER_SUBSYS} create $TTY --rm --privileged \
 -e "OCM_URL" \
@@ -212,6 +231,7 @@ ${OPS_UTILS_DIR_MOUNT} \
 ${SCRATCH_DIR_MOUNT} \
 ${PORT_MAP_OPTS} \
 ${OCM_CONTAINER_LAUNCH_OPTS} \
+${BACKPLANE_CONFIG_MOUNT} \
 ocm-container:${BUILD_TAG} ${EXEC_SCRIPT})
 
 $CONTAINER_SUBSYS start $CONTAINER > /dev/null

--- a/utils/bashrc.d/06-sre-utils.bashrc
+++ b/utils/bashrc.d/06-sre-utils.bashrc
@@ -18,5 +18,9 @@ then
 fi
 
 function cluster_function() {
-  oc config view  --minify --output 'jsonpath={..server}' | cut -d. -f2-4
+  info="$(ocm backplane status 2> /dev/null)"
+  if [ $? -ne 0 ]; then return; fi
+  clustername=$(grep "Cluster Name" <<< $info | awk '{print $3}')
+  baseid=$(grep "Cluster Basedomain" <<< $info | awk '{print $3}' | cut -d'.' -f1,2)
+  echo $clustername.$baseid
 }

--- a/utils/bin/sre-login
+++ b/utils/bin/sre-login
@@ -64,6 +64,4 @@ cluster_listening=$(jq -r '.api.listening' <<< "$clusterjson")
 # Login to the Cluster
 
 echo "Cluster ID: $cluster_id"
-ocm backplane tunnel -D > tunnel.log
 exec ocm backplane login ${cluster_id}
-

--- a/utils/dockerfile_assets/containers.conf
+++ b/utils/dockerfile_assets/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"


### PR DESCRIPTION
The api url is different with the new backplane so our old method of finding the cluster name does not work.
This seems to fix it.
Shamelessly copied from [here](https://github.com/openshift/backplane-cli/blob/main/docs/PS1-setup.md#bash)